### PR TITLE
add comment about languageLabels

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,7 +1,10 @@
 // languageLabels is a dictionary that maps message from language codes to the corresponding language
+// Default languageLabels is 'last updated on'
+// Add more languageLabels as needed
 const languageLabels = {
   'ja-jp': '英語版の更新日',
   // Add more language labels as needed
+  // ex. 'fr-fr': 'Dernière mise à jour le',
 };
 
 (async () => {

--- a/src/content.js
+++ b/src/content.js
@@ -3,8 +3,7 @@
 // Add more languageLabels as needed
 const languageLabels = {
   'ja-jp': '英語版の更新日',
-  // Add more language labels as needed
-  // ex. 'fr-fr': 'Dernière mise à jour le',
+  // Add more language labels as needed. For example: 'fr-fr': 'Dernière mise à jour le',
 };
 
 (async () => {


### PR DESCRIPTION
This pull request includes a small change to the `src/content.js` file. The change adds comments to the `languageLabels` dictionary to clarify its purpose and usage.

* [`src/content.js`](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fR2-R7): Added comments to explain that `languageLabels` maps language codes to their corresponding labels and provided an example for adding more labels.