### PR TITLE
Bump up to 1.5

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "learn.microsoft.com Update Checker",
-  "version": "1.4",
+  "version": "1.5",
   "description": "Displays the 'en-us' version update date of Microsoft Learn pages. It compares the English version with the current language version and highlights the date if the current version is outdated.",
   "permissions": [],
   "icons": {


### PR DESCRIPTION
This pull request includes a small change to the `manifest.json` file. The change updates the version number of the "learn.microsoft.com Update Checker" extension from 1.4 to 1.5.

* [`manifest.json`](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L4-R4): Updated the version number from 1.4 to 1.5.