### PR TITLE
Manifest description field is too long (192). Maximum length is 132 characters.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "learn.microsoft.com Update Checker",
   "version": "1.5",
-  "description": "Displays the 'en-us' version update date of Microsoft Learn pages. It compares the English version with the current language version and highlights the date if the current version is outdated.",
+  "description": "Displays the 'en-us' update date of Microsoft Learn pages and highlights it if the current language version is outdated.",
   "permissions": [],
   "icons": {
     "16": "icons/icon16.png",


### PR DESCRIPTION
This pull request includes a minor change to the `manifest.json` file. The change simplifies the description of the extension.

* [`manifest.json`](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L5-R5): Simplified the description to make it more concise and easier to understand.