### PR TITLE
Switched from the data-article-date Element to Using the local-time Tag

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -36,8 +36,8 @@ const timeAgoLabels = {
 
   const debug = new URLSearchParams(window.location.search).get("jp-learn-microsoft-com-update-checker-debug");
 
-  // Get data-article-date element in current page
-  const dataArticleDateElement = document.querySelector('time[data-article-date]');
+  // Get local-time tag in current page
+  const dataArticleDateElement = document.querySelector('local-time');
   if (!dataArticleDateElement) return;
 
   // Parse article date
@@ -56,7 +56,7 @@ const timeAgoLabels = {
     const parser = new DOMParser();
     const doc = parser.parseFromString(data, "text/html");
 
-    const englishDateStr = doc.querySelector('time[data-article-date]')?.getAttribute("datetime");
+    const englishDateStr = doc.querySelector('local-time')?.getAttribute("datetime");
     if (!englishDateStr) return;
     const englishDate = new Date(englishDateStr);
 

--- a/tests/e2e/content.e2e.test.js
+++ b/tests/e2e/content.e2e.test.js
@@ -100,8 +100,8 @@ describe('learn.microsoft.com Update Checker E2E Test', () => {
         }, testCase.themeColor);
         await page.waitForSelector('button[aria-pressed="true"]');
 
-        // Wait for the time element with the 'data-article-date' attribute to be added
-        await page.waitForSelector('time[data-article-date]');
+        // Wait for the time element with the 'local-time' attribute to be added
+        await page.waitForSelector('local-time');
 
         const englishDateText = await page.evaluate((expectedText) => {
           return new Promise(resolve => setTimeout(resolve, 1000)) // Add a delay to allow time for the element to be added


### PR DESCRIPTION
## Why

This extension hasn’t been working recently.

## What

Recently, learn.microsoft.com switched from using the data-article-date to local-time. Since this extension was retrieving dates from data-article-date, it stopped functioning. Therefore, we will update it to extract the dates from local-time.

This pull request includes changes to update the selector for date elements from `time[data-article-date]` to `local-time` in both the source code and the end-to-end tests. The most important changes include updating the selector in the `src/content.js` file and modifying the E2E test in `tests/e2e/content.e2e.test.js`.

Updates to date element selector:

* [`src/content.js`](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fL39-R40): Changed the selector from `time[data-article-date]` to `local-time` in the `dataArticleDateElement` query and in the `englishDateStr` query. [[1]](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fL39-R40) [[2]](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fL59-R59)

Modifications to E2E tests:

* [`tests/e2e/content.e2e.test.js`](diffhunk://#diff-e8cb743dad92fd8d4eaea95cf7cc9de07fa1f48592ead95fbc4f75cd580ca45fL103-R104): Updated the selector in the E2E test to wait for the `local-time` element instead of `time[data-article-date]`.

## Manual Test

- https://learn.microsoft.com/ja-jp/azure/well-architected/service-guides/azure-front-door

![image](https://github.com/user-attachments/assets/ddf1b37b-af8a-4484-b1df-5565d1ae5587)

- https://learn.microsoft.com/en-us/azure/well-architected/service-guides/azure-front-door

![image](https://github.com/user-attachments/assets/9a6f1c20-eceb-48b5-8343-0a3f6d307a78)

- https://learn.microsoft.com/zh-cn/azure/well-architected/service-guides/azure-front-door

![image](https://github.com/user-attachments/assets/8606c895-2a5b-4a5f-97c4-06aae0d500b6)
