### PR TITLE
Bump up to 1.7

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "learn.microsoft.com Update Checker",
-  "version": "1.6",
+  "version": "1.7",
   "description": "Displays the 'en-us' update date of Microsoft Learn pages and highlights it if the current language version is outdated.",
   "permissions": [],
   "icons": {


### PR DESCRIPTION
This pull request includes a minor update to the `manifest.json` file. The change updates the version number from 1.6 to 1.7.

* [`manifest.json`](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L4-R4): Updated the version number from 1.6 to 1.7.